### PR TITLE
Code to extract a Transaction instance from a (possibly base64-encoded) XDR envelope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'ivy-publish'
 
 sourceCompatibility = 1.6
-version = '0.1.13'
+version = '0.1.14'
 group = 'stellar'
 
 jar {

--- a/src/main/java/org/stellar/sdk/Memo.java
+++ b/src/main/java/org/stellar/sdk/Memo.java
@@ -1,6 +1,7 @@
 package org.stellar.sdk;
 
 import org.apache.commons.codec.DecoderException;
+import org.stellar.sdk.xdr.MemoType;
 
 /**
  * <p>The memo contains optional extra information. It is the responsibility of the client to interpret this value. Memos can be one of the following types:</p>
@@ -73,4 +74,30 @@ public abstract class Memo {
     }
 
     abstract org.stellar.sdk.xdr.Memo toXdr();
+
+    /**
+     * Creates new Memo from XDR-encoded memo.
+     * @param xdrMemo
+     * @return the new Memo instance
+     */
+    public static Memo fromXdr(org.stellar.sdk.xdr.Memo xdrMemo) {
+        MemoType memoType = xdrMemo.getDiscriminant();
+        switch (memoType) {
+            case MEMO_NONE:
+                return none();
+            case MEMO_TEXT:
+                return text(xdrMemo.getText());
+            case MEMO_ID:
+                return id(xdrMemo.getId().getUint64());
+            case MEMO_HASH:
+                return hash(xdrMemo.getHash().getHash());
+            case MEMO_RETURN:
+                return returnHash(xdrMemo.getRetHash().getHash());
+            default:
+                // all possible cases were covered above,
+                // so this code should never be reached
+                throw new RuntimeException("Unknown enum value:" + memoType);
+        }
+    }
+
 }

--- a/src/main/java/org/stellar/sdk/TimeBounds.java
+++ b/src/main/java/org/stellar/sdk/TimeBounds.java
@@ -15,8 +15,8 @@ final public class TimeBounds {
 	 * @param maxTime 64bit Unix timestamp
 	 */
 	public TimeBounds(long minTime, long maxTime) {
-		if(minTime >= maxTime) {
-			throw new IllegalArgumentException("minTime must be >= maxTime");
+		if (minTime > maxTime) {
+			throw new IllegalArgumentException("minTime must be <= maxTime");
 		}
 		
 		mMinTime = minTime;

--- a/src/test/java/org/stellar/sdk/TransactionTest.java
+++ b/src/test/java/org/stellar/sdk/TransactionTest.java
@@ -109,6 +109,20 @@ public class TransactionTest {
   }
 
   @Test
+  public void testTransactionFromEnvelopeXdrBase64() {
+    String xdrBase64Envelope;
+    Transaction tx;
+
+    xdrBase64Envelope = "AAAAAF7FIiDToW1fOYUFBC0dmyufJbFTOa2GQESGz+S2h5ViAAAAZAAKVaMAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAAEqBfIAAAAAAAAAAABtoeVYgAAAEDzfR5PgRFim5Wdvq9ImdZNWGBxBWwYkQPa9l5iiBdtPLzAZv6qj+iOfSrqinsoF0XrLkwdIcZQVtp3VRHhRoUE";
+    tx = Transaction.fromEnvelope(Transaction.decodeBase64XdrEnvelope(xdrBase64Envelope));
+    assertEquals(xdrBase64Envelope, tx.toEnvelopeXdrBase64());
+
+    xdrBase64Envelope = "AAAAANsc5j01PQN1UKWKTdrD6vv0wBgXxBW5D+mhHV/i5nKQAAAAZABlcJIAAAAGAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAANzIBPq8a7WNSxKoZfsLmrGETqAfr4iGPmxRrQLEsHQSAAAAAAAAAAEqBfIAAAAAAAAAAAHi5nKQAAAAQM9vvEUpodJbquHyUyCfqTw21h9/iajVIl6KyQOE13GKmpPQDXXop/NKHEy+7da0QkH7l8g0uztw/u0C5tk4zgg=";
+    tx = Transaction.fromEnvelope(Transaction.decodeBase64XdrEnvelope(xdrBase64Envelope));
+    assertEquals(xdrBase64Envelope, tx.toEnvelopeXdrBase64());
+  }
+
+  @Test
   public void testSha256HashSigning() throws FormatException {
     Network.usePublicNetwork();
 


### PR DESCRIPTION
Obtaining a Transaction instance from a base64-encoded XDR envelope is useful for a program that (1) somehow obtains a string representing a signed but not yet submitted transaction, (2) lets the user check if the transaction data is correct, and (3) sends the transaction to the Stellar network. The program may be a mobile app that gets the transaction string by scanning a QR code produced by a cold storage wallet.

I changed the TimeBounds class because the Stellar Laboratory generates transactions with minTIme==maxTime==0. Without the TimeBounds change, extracting such a transaction from an envelope would generate an IllegalArgumentException. 