### PR TITLE
refactor!: refactor the way of constructing `Predicate.Or` and `Predicate.And`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 - refactor!: `FeeBumpTransaction.Builder` has been removed, use `FeeBumpTransaction#FeeBumpTransaction(String, long, Transaction)` instead.
 - refactor!: `FeeBumpTransaction.getFeeAccount` has been removed, use `FeeBumpTransaction.getFeeSource` instead.
 - refactor!: remove `AccountConverter`, this means that we no longer support disabling support for MuxedAccount.
+- refactor!: refactor the way of constructing `Predicate.Or` and `Predicate.And`. The `inner` inside has been removed, and in its place are `left` and `right`, used to represent two predicates.
 
 ## 0.44.0
 ### Update

--- a/examples/src/main/java/network/lightsail/Payment.java
+++ b/examples/src/main/java/network/lightsail/Payment.java
@@ -51,7 +51,7 @@ public class Payment {
             .setBaseFee(MIN_BASE_FEE) // set base fee, see
             // https://developers.stellar.org/docs/learn/glossary#base-fee
             .addMemo(Memo.text("Hello Stellar!")) // Add a text memo
-            .setTimeout(180) // Make this transaction valid for the next 30 seconds only
+            .setTimeout(30) // Make this transaction valid for the next 30 seconds only
             .addOperation(paymentOperation) // Add the payment operation to the transaction
             .build();
 

--- a/src/main/java/org/stellar/sdk/Predicate.java
+++ b/src/main/java/org/stellar/sdk/Predicate.java
@@ -2,8 +2,6 @@ package org.stellar.sdk;
 
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,28 +15,20 @@ import org.stellar.sdk.xdr.XdrUnsignedHyperInteger;
 
 /** Base class for predicates. */
 public abstract class Predicate {
-
-  private static List<Predicate> convertXDRPredicates(ClaimPredicate[] predicates) {
-    List<Predicate> list = new ArrayList<>();
-    for (ClaimPredicate p : predicates) {
-      list.add(fromXdr(p));
-    }
-    return list;
-  }
-
   /**
-   * Generates Predicate object from a given XDR object
+   * Generates Predicate object from a given XDR object.
    *
    * @param xdr XDR object
+   * @return Predicate object
    */
   public static Predicate fromXdr(org.stellar.sdk.xdr.ClaimPredicate xdr) {
     switch (xdr.getDiscriminant()) {
       case CLAIM_PREDICATE_UNCONDITIONAL:
         return new Unconditional();
       case CLAIM_PREDICATE_AND:
-        return new And(convertXDRPredicates(xdr.getAndPredicates()));
+        return new And(fromXdr(xdr.getAndPredicates()[0]), fromXdr(xdr.getAndPredicates()[1]));
       case CLAIM_PREDICATE_OR:
-        return new Or(convertXDRPredicates(xdr.getOrPredicates()));
+        return new Or(fromXdr(xdr.getOrPredicates()[0]), fromXdr(xdr.getOrPredicates()[1]));
       case CLAIM_PREDICATE_NOT:
         return new Not(fromXdr(xdr.getNotPredicate()));
       case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
@@ -46,14 +36,18 @@ public abstract class Predicate {
       case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
         return new AbsBefore(xdr.getAbsBefore().getInt64());
       default:
-        throw new IllegalArgumentException("Unknown asset type " + xdr.getDiscriminant());
+        throw new IllegalArgumentException("Unknown predicate type: " + xdr.getDiscriminant());
     }
   }
 
   @Override
   public abstract boolean equals(Object object);
 
-  /** Generates XDR object from a given Asset object */
+  /**
+   * Generates XDR object from a given Predicate object.
+   *
+   * @return XDR object
+   */
   public abstract org.stellar.sdk.xdr.ClaimPredicate toXdr();
 
   /** Represents a predicate that is always true. */
@@ -67,10 +61,12 @@ public abstract class Predicate {
     }
   }
 
+  /** Represents a logical NOT of a predicate. */
   @EqualsAndHashCode(callSuper = false)
   @AllArgsConstructor
   @Getter
   public static class Not extends Predicate {
+    /** The inner predicate to negate. */
     private final Predicate inner;
 
     @Override
@@ -82,52 +78,52 @@ public abstract class Predicate {
     }
   }
 
+  /** Represents a logical OR of two predicates. */
   @EqualsAndHashCode(callSuper = false)
   @AllArgsConstructor
   @Getter
   public static class Or extends Predicate {
-    private final List<Predicate> inner;
+    /** The left predicate. */
+    private final Predicate left;
+
+    /** The right predicate. */
+    private final Predicate right;
 
     @Override
     public ClaimPredicate toXdr() {
       org.stellar.sdk.xdr.ClaimPredicate xdr = new org.stellar.sdk.xdr.ClaimPredicate();
       xdr.setDiscriminant(ClaimPredicateType.CLAIM_PREDICATE_OR);
-      ClaimPredicate[] xdrInner = new ClaimPredicate[inner.size()];
-      for (int i = 0; i < inner.size(); i++) {
-        xdrInner[i] = inner.get(i).toXdr();
-      }
-      xdr.setOrPredicates(xdrInner);
+      xdr.setOrPredicates(new ClaimPredicate[] {left.toXdr(), right.toXdr()});
       return xdr;
     }
   }
 
+  /** Represents a logical AND of two predicates. */
   @EqualsAndHashCode(callSuper = false)
   @AllArgsConstructor
   @Getter
   public static class And extends Predicate {
-    private final List<Predicate> inner;
+    /** The left predicate. */
+    private final Predicate left;
+
+    /** The right predicate. */
+    private final Predicate right;
 
     @Override
     public ClaimPredicate toXdr() {
       org.stellar.sdk.xdr.ClaimPredicate xdr = new org.stellar.sdk.xdr.ClaimPredicate();
       xdr.setDiscriminant(ClaimPredicateType.CLAIM_PREDICATE_AND);
-      ClaimPredicate[] xdrInner = new ClaimPredicate[inner.size()];
-      for (int i = 0; i < inner.size(); i++) {
-        xdrInner[i] = inner.get(i).toXdr();
-      }
-      xdr.setAndPredicates(xdrInner);
+      xdr.setAndPredicates(new ClaimPredicate[] {left.toXdr(), right.toXdr()});
       return xdr;
     }
   }
 
-  /** Represents a predicate based on a maximum date and time. */
+  /** Represents a predicate based on a maximum absolute timestamp. */
   @EqualsAndHashCode(callSuper = false)
+  @AllArgsConstructor
   public static class AbsBefore extends Predicate {
+    /** The maximum absolute timestamp in seconds. */
     private final TimePoint timePoint;
-
-    public AbsBefore(TimePoint timePoint) {
-      this.timePoint = timePoint;
-    }
 
     public AbsBefore(long epochSeconds) {
       this(new TimePoint(new Uint64(new XdrUnsignedHyperInteger(epochSeconds))));
@@ -138,9 +134,9 @@ public abstract class Predicate {
     }
 
     /**
-     * Gets the Predicate epoch in seconds.
+     * Gets the predicate timestamp in seconds.
      *
-     * @return BigInteger the predicate epoch in seconds
+     * @return the predicate timestamp in seconds
      */
     public BigInteger getTimestampSeconds() {
       return timePoint.getTimePoint().getUint64().getNumber();
@@ -156,12 +152,11 @@ public abstract class Predicate {
      * @return Instant the java date representation of the predicate
      */
     public Instant getDate() {
-      Instant instantMax = Instant.MAX;
-      if (getTimestampSeconds().compareTo(BigInteger.valueOf(instantMax.getEpochSecond())) > 0) {
-        return instantMax;
+      BigInteger seconds = getTimestampSeconds();
+      if (seconds.compareTo(BigInteger.valueOf(Instant.MAX.getEpochSecond())) > 0) {
+        return Instant.MAX;
       }
-
-      return Instant.ofEpochSecond(timePoint.getTimePoint().getUint64().getNumber().longValue());
+      return Instant.ofEpochSecond(seconds.longValue());
     }
 
     @Override
@@ -173,16 +168,31 @@ public abstract class Predicate {
     }
   }
 
-  /** Represents predicate based on maximum length of time */
+  /**
+   * Represents a predicate based on a relative time offset from the close time of the ledger in
+   * which the {@link org.stellar.sdk.operations.CreateClaimableBalanceOperation} is included.
+   */
   @EqualsAndHashCode(callSuper = false)
   @AllArgsConstructor
   public static class RelBefore extends Predicate {
+    /** The relative time offset in seconds from the close time of the ledger. */
     private final Duration duration;
 
+    /**
+     * Creates a new predicate based on a relative time offset from the close time of the ledger.
+     *
+     * @param secondsSinceClose the relative time offset in seconds from the close time of the
+     *     ledger
+     */
     public RelBefore(long secondsSinceClose) {
       this(new Duration(new Uint64(new XdrUnsignedHyperInteger(secondsSinceClose))));
     }
 
+    /**
+     * Gets the relative time offset in seconds.
+     *
+     * @return the relative time offset in seconds
+     */
     public long getSecondsSinceClose() {
       return duration.getDuration().getUint64().getNumber().longValue();
     }

--- a/src/main/java/org/stellar/sdk/responses/PredicateDeserializer.java
+++ b/src/main/java/org/stellar/sdk/responses/PredicateDeserializer.java
@@ -29,7 +29,7 @@ public class PredicateDeserializer implements JsonDeserializer<Predicate> {
       for (JsonElement elt : obj.get("and").getAsJsonArray()) {
         inner.add(deserialize(elt, typeOfT, context));
       }
-      return new Predicate.And(inner);
+      return new Predicate.And(inner.get(0), inner.get(1));
     }
 
     if (obj.has("or")) {
@@ -37,7 +37,7 @@ public class PredicateDeserializer implements JsonDeserializer<Predicate> {
       for (JsonElement elt : obj.get("or").getAsJsonArray()) {
         inner.add(deserialize(elt, typeOfT, context));
       }
-      return new Predicate.Or(inner);
+      return new Predicate.Or(inner.get(0), inner.get(1));
     }
 
     // backwards compatible for abs before, uses the newer abs_before_epoch if available from server

--- a/src/test/java/org/stellar/sdk/responses/ClaimableBalancePageDeserializerTest.java
+++ b/src/test/java/org/stellar/sdk/responses/ClaimableBalancePageDeserializerTest.java
@@ -48,9 +48,8 @@ public class ClaimableBalancePageDeserializerTest extends TestCase {
     Predicate.Or or =
         (Predicate.Or)
             claimableBalancePage.getRecords().get(0).getClaimants().get(0).getPredicate();
-    assertEquals(or.getInner().size(), 2);
-    Predicate.AbsBefore absBefore = (Predicate.AbsBefore) or.getInner().get(0);
-    Predicate.RelBefore relBefore = (Predicate.RelBefore) or.getInner().get(1);
+    Predicate.AbsBefore absBefore = (Predicate.AbsBefore) or.getLeft();
+    Predicate.RelBefore relBefore = (Predicate.RelBefore) or.getRight();
     assertEquals(absBefore.getDate().toString(), "2020-09-28T17:57:04Z");
     assertEquals(relBefore.getSecondsSinceClose(), 12L);
     assertEquals(
@@ -83,10 +82,9 @@ public class ClaimableBalancePageDeserializerTest extends TestCase {
     Predicate.And and =
         (Predicate.And)
             claimableBalancePage.getRecords().get(1).getClaimants().get(0).getPredicate();
-    assertEquals(and.getInner().size(), 2);
-    absBefore = (Predicate.AbsBefore) and.getInner().get(0);
+    absBefore = (Predicate.AbsBefore) and.getLeft();
     assertEquals(absBefore.getDate().toString(), "2020-09-28T17:57:04Z");
-    Predicate.Not not = (Predicate.Not) and.getInner().get(1);
+    Predicate.Not not = (Predicate.Not) and.getRight();
     assertEquals(new Predicate.Unconditional(), not.getInner());
 
     for (ClaimableBalanceResponse record : claimableBalancePage.getRecords()) {


### PR DESCRIPTION
The "inner" inside has been removed, and in its place are "left" and "right," used to represent two conditions.