### PR TITLE
refactor!: remove `rateLimitLimit`, `rateLimitRemaining`, and `rateLimitReset` from the `Response`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
   - Removed some methods.
   - Some field names have been changed to maintain consistency with the Horizon API.
   - Removed all functions that return `Optional` value.
+- refactor!: remove `rateLimitLimit`, `rateLimitRemaining`, and `rateLimitReset` from the `Response`.
 
 ## 0.44.0
 ### Update

--- a/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
+++ b/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
@@ -75,9 +75,6 @@ public class ResponseHandler<T> {
 
       if (response.code() >= 200 && response.code() < 300) {
         T object = GsonSingleton.getInstance().fromJson(content, type.getType());
-        if (object instanceof org.stellar.sdk.responses.Response) {
-          ((org.stellar.sdk.responses.Response) object).setHeaders(response.headers());
-        }
         if (object instanceof TypedResponse) {
           ((TypedResponse<T>) object).setType(type);
         }

--- a/src/main/java/org/stellar/sdk/responses/Response.java
+++ b/src/main/java/org/stellar/sdk/responses/Response.java
@@ -1,54 +1,12 @@
 package org.stellar.sdk.responses;
 
 import lombok.Getter;
-import okhttp3.Headers;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.LiquidityPoolID;
 import org.stellar.sdk.TrustLineAsset;
 
 @Getter
 public abstract class Response {
-  /**
-   * Returns X-RateLimit-Limit header from the response. This number represents the he maximum
-   * number of requests that the current client can make in one hour.
-   *
-   * @see <a href="https://developers.stellar.org/api/introduction/rate-limiting/"
-   *     target="_blank">Rate Limiting</a>
-   */
-  protected int rateLimitLimit;
-
-  /**
-   * Returns X-RateLimit-Remaining header from the response. The number of remaining requests for
-   * the current window.
-   *
-   * @see <a href="https://developers.stellar.org/api/introduction/rate-limiting/"
-   *     target="_blank">Rate Limiting</a>
-   */
-  protected int rateLimitRemaining;
-
-  /**
-   * Returns X-RateLimit-Reset header from the response. Seconds until a new window starts.
-   *
-   * @see <a href="https://developers.stellar.org/api/introduction/rate-limiting/"
-   *     target="_blank">Rate Limiting</a>
-   */
-  protected int rateLimitReset;
-
-  public void setHeaders(Headers headers) {
-    String limitHeader = headers.get("X-Ratelimit-Limit");
-    if (limitHeader != null) {
-      this.rateLimitLimit = Integer.parseInt(limitHeader);
-    }
-    String remainingHeader = headers.get("X-Ratelimit-Remaining");
-    if (remainingHeader != null) {
-      this.rateLimitRemaining = Integer.parseInt(remainingHeader);
-    }
-    String resetHeader = headers.get("X-Ratelimit-Reset");
-    if (resetHeader != null) {
-      this.rateLimitReset = Integer.parseInt(resetHeader);
-    }
-  }
-
   protected static TrustLineAsset getTrustLineAsset(
       String type, String code, String issuer, String liquidityPoolId) {
     if ("liquidity_pool_shares".equals(type)) {


### PR DESCRIPTION
Horizon will no longer return these headers.