### PR TITLE
Add `toBigInteger()` to 128-bit and 256-bit integers

### DIFF
--- a/src/main/java/org/stellar/sdk/xdr/Int128Parts.java
+++ b/src/main/java/org/stellar/sdk/xdr/Int128Parts.java
@@ -5,6 +5,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -44,6 +45,12 @@ public class Int128Parts implements XdrElement {
   public static Int128Parts fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
+  }
+
+  public BigInteger toBigInteger() {
+    BigInteger hiValue = BigInteger.valueOf(hi.getInt64());
+    BigInteger loValue = lo.getUint64().getNumber();
+    return hiValue.shiftLeft(64).add(loValue);
   }
 
   public static Int128Parts fromXdrByteArray(byte[] xdr) throws IOException {

--- a/src/main/java/org/stellar/sdk/xdr/Int256Parts.java
+++ b/src/main/java/org/stellar/sdk/xdr/Int256Parts.java
@@ -5,6 +5,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -52,6 +53,19 @@ public class Int256Parts implements XdrElement {
   public static Int256Parts fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
+  }
+
+  public BigInteger toBigInteger() {
+    BigInteger hi_hiValue = BigInteger.valueOf(hi_hi.getInt64());
+    BigInteger hi_loValue = hi_lo.getUint64().getNumber();
+    BigInteger lo_hiValue = lo_hi.getUint64().getNumber();
+    BigInteger lo_loValue = lo_lo.getUint64().getNumber();
+
+    return hi_hiValue
+        .shiftLeft(192)
+        .add(hi_loValue.shiftLeft(128))
+        .add(lo_hiValue.shiftLeft(64))
+        .add(lo_loValue);
   }
 
   public static Int256Parts fromXdrByteArray(byte[] xdr) throws IOException {

--- a/src/main/java/org/stellar/sdk/xdr/UInt128Parts.java
+++ b/src/main/java/org/stellar/sdk/xdr/UInt128Parts.java
@@ -5,6 +5,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -44,6 +45,12 @@ public class UInt128Parts implements XdrElement {
   public static UInt128Parts fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
+  }
+
+  public BigInteger toBigInteger() {
+    BigInteger hiValue = hi.getUint64().getNumber();
+    BigInteger loValue = lo.getUint64().getNumber();
+    return hiValue.shiftLeft(64).add(loValue);
   }
 
   public static UInt128Parts fromXdrByteArray(byte[] xdr) throws IOException {

--- a/src/main/java/org/stellar/sdk/xdr/UInt256Parts.java
+++ b/src/main/java/org/stellar/sdk/xdr/UInt256Parts.java
@@ -5,6 +5,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -47,6 +48,18 @@ public class UInt256Parts implements XdrElement {
     decodedUInt256Parts.lo_hi = Uint64.decode(stream);
     decodedUInt256Parts.lo_lo = Uint64.decode(stream);
     return decodedUInt256Parts;
+  }
+
+  public BigInteger toBigInteger() {
+    BigInteger hi_hiValue = hi_hi.getUint64().getNumber();
+    BigInteger hi_loValue = hi_lo.getUint64().getNumber();
+    BigInteger lo_hiValue = lo_hi.getUint64().getNumber();
+    BigInteger lo_loValue = lo_lo.getUint64().getNumber();
+    return hi_hiValue
+        .shiftLeft(192)
+        .add(hi_loValue.shiftLeft(128))
+        .add(lo_hiValue.shiftLeft(64))
+        .add(lo_loValue);
   }
 
   public static UInt256Parts fromXdrBase64(String xdr) throws IOException {

--- a/src/main/java/org/stellar/sdk/xdr/Uint256.java
+++ b/src/main/java/org/stellar/sdk/xdr/Uint256.java
@@ -5,6 +5,7 @@ package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,10 @@ public class Uint256 implements XdrElement {
     decodedUint256.uint256 = new byte[uint256Size];
     stream.read(decodedUint256.uint256, 0, uint256Size);
     return decodedUint256;
+  }
+
+  public BigInteger toBigInteger() {
+    return new BigInteger(1, uint256);
   }
 
   public static Uint256 fromXdrBase64(String xdr) throws IOException {


### PR DESCRIPTION
In Anchor Platform, we have to convert int128 to BigInteger. It would be nice for the SDK to support these functions as well for convenience. 

I did not find any helper functions. Let me know if these functions already exist.