### PR TITLE
fix: fix handling of transaction metadata versioning in `AssembledTransaction` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat: add `isValidSignedPayload` to `StrKey` class, this function can be used to validate the ed25519 signed payload. ([#712](https://github.com/stellar/java-stellar-sdk/pull/712))
 - feat: add `signExtraSignersPayload` to sign extra signers payloads in `Transaction` class. ([#713](https://github.com/stellar/java-stellar-sdk/pull/713))
 - refactor: add balance id validation. ([#722](https://github.com/stellar/java-stellar-sdk/pull/722))
+- fix: fix handling of transaction metadata versioning in `AssembledTransaction` class. ([#723](https://github.com/stellar/java-stellar-sdk/pull/723))
 
 ### Breaking changes:
 - feat: add `org.stellar.sdk.SignerKey` for enhanced signer key handling. ([#712](https://github.com/stellar/java-stellar-sdk/pull/712))

--- a/src/main/java/org/stellar/sdk/contract/AssembledTransaction.java
+++ b/src/main/java/org/stellar/sdk/contract/AssembledTransaction.java
@@ -379,7 +379,12 @@ public class AssembledTransaction<T> {
       throw new IllegalArgumentException(
           "Unable to convert transaction meta to TransactionMeta", e);
     }
-    SCVal resultVal = transactionMeta.getV3().getSorobanMeta().getReturnValue();
+    SCVal resultVal;
+    if (transactionMeta.getV3() != null) {
+      resultVal = transactionMeta.getV3().getSorobanMeta().getReturnValue();
+    } else {
+      resultVal = transactionMeta.getV4().getSorobanMeta().getReturnValue();
+    }
     return parseResultXdrFn != null ? parseResultXdrFn.apply(resultVal) : (T) resultVal;
   }
 


### PR DESCRIPTION
Ensure compatibility with both V3 and V4 by checking for null values before accessing Soroban metadata.